### PR TITLE
Fix undefined warning when generating music charts

### DIFF
--- a/modules/Pisg/Parser/Logfile.pm
+++ b/modules/Pisg/Parser/Logfile.pm
@@ -746,7 +746,11 @@ sub _uniquify_nicks {
                 $stats->{word_upcase}{$realnick} ||= $stats->{word_upcase}{$word};
                 delete $stats->{wordcounts}{$word};
                 delete $stats->{wordnicks}{$word};
-                delete $stats->{word_upcase}{$word};
+                # We need the word case translation around if it is used as a
+                # song name.
+                if (!defined $stats->{chartcounts}{$word}) {
+                  delete $stats->{word_upcase}{$word};
+                }
             }
         }
     }


### PR DESCRIPTION
This is a fix for a warning that started happening for me recently:

`Use of uninitialized value $song in numeric gt (>) at /usr/share/perl5/Pisg/HTMLGenerator.pm  
line 2078.`

`Use of uninitialized value $str in split at /usr/share/perl5/Pisg/HTMLGenerator.pm line 2132.`

What is happening is we are trying to get the the non-lowercased version of the song information:

`$song = $self->{stats}->{word_upcase}{$song};`
`$song = substr($song, 0, 60) if (length($song) > 60);
`

But it was deleted from `word_upcase` when in `_uniquify_nicks`.

To fix this I check if the word is in the `chartcounts` hash before deleting it, and don't delete it if it is there. I saw that this same check (to not delete from `word_upcase` was done in a different spot in `Logfile.pm` already - in the final loop in `_parse_file`).

I am letting the word be deleted from `wordcounts` and `wordnicks`. From what I can tell, this makes sense.

Further background: Apparently the word "what" was recognized as a song play. Someone in the channel in the log said "playing what". I have an alias set for someone who used the nick "what". This lead to `_uniquify_nicks` thinking a nick was a song and deleting it. An odd situation where a song name matched a nick I suppose.
