### PR TITLE
Don't treat thirdlines from nick 'Mode' as Mode changes in weechat3

### DIFF
--- a/modules/Pisg/Parser/Format/weechat3.pm
+++ b/modules/Pisg/Parser/Format/weechat3.pm
@@ -73,11 +73,6 @@ sub thirdline
             $hash{newtopic} =~ m/" to "(.*)"/;
             $hash{newtopic} = $1;
 
-        } elsif ($3 eq 'Mode') {
-            $hash{newmode} = substr($5, 1);
-            $hash{nick} = $8 || $7;
-            $hash{nick} =~ s/.* (\S+)$/$1/; # Get the last word of the string
-
         } elsif (($5.$6) eq 'hasjoined') {
             $hash{newjoin} = $3;
 
@@ -85,6 +80,10 @@ sub thirdline
             if ($8 =~ /^\s+(\S+)/) {
                 $hash{newnick} = $1;
             }
+        } elsif ($3 eq 'Mode') {
+            $hash{newmode} = substr($5, 1);
+            $hash{nick} = $8 || $7;
+            $hash{nick} =~ s/.* (\S+)$/$1/; # Get the last word of the string
         }
 
         return \%hash;


### PR DESCRIPTION
If anyone has the nick 'Mode' and appears in a thirdline, this line will be
treated as a Mode change of another nick, and will fail to be parsed.
This happens when, for example, a user changes their nick from 'Mode' to
something else.

This patch changes the order the different thirdline types are detected so that
a mode change is the very last type. This means that nick changes and other
thirdlines are caught first and handled correctly.
