### PR TITLE
Update my email address in CREDITS

### DIFF
--- a/docs/CREDITS
+++ b/docs/CREDITS
@@ -8,7 +8,7 @@ Major contributions:
 
   - Winfried Nessen <doomy(at)doomshammer.yi.org>
   - Jamie Cheetham <jamie(at)softham.co.uk>
-  - Sam Bingner <sam(at)dhs.org>
+  - Sam Bingner <sam(at)bingner.com>
   - Torbjörn Svensson <azoff(at)se.linux.org>: ShowFoulDecimals and AltColorScheme
     options, multiple channels with same name, multiple languages per run,
     lots of other fixes, pum.pl


### PR DESCRIPTION
It may be helpful to have my proper email address in the credits.  That address is deprecated.